### PR TITLE
Added training with custom data support, fixed bugs with ddpm

### DIFF
--- a/polyffusion/chord_extractor/__init__.py
+++ b/polyffusion/chord_extractor/__init__.py
@@ -5,7 +5,7 @@ import numpy as np
 import csv
 
 
-def get_chord_from_chdfile(fpath, one_beat=0.5):
+def get_chord_from_chdfile(fpath, one_beat=0.5, rounding=True):
     """
     chord matrix [M * 14], each line represent the chord of a beat
     same format as mir_eval.chord.encode():
@@ -19,8 +19,11 @@ def get_chord_from_chdfile(fpath, one_beat=0.5):
         start = float(line[0])
         end = float(line[1])
         chord = line[2]
-        assert ((end - start) / one_beat).is_integer()
-        beat_num = int((end - start) / one_beat)
+        if not rounding:
+            assert ((end - start) / one_beat).is_integer()
+            beat_num = int((end - start) / one_beat)
+        else:
+            beat_num = round((end - start) / one_beat)
         for _ in range(beat_num):
             beat_cnt += 1
             # see https://craffel.github.io/mir_eval/#mir_eval.chord.encode

--- a/polyffusion/data/dataloader.py
+++ b/polyffusion/data/dataloader.py
@@ -19,7 +19,7 @@ from utils import (
 
 def collate_fn(batch, shift):
     def sample_shift():
-        return np.random.choice(np.arange(-6, 7), 1)[0]
+        return np.random.choice(np.arange(-6, 6), 1)[0]
 
     prmat2c = []
     pnotree = []

--- a/polyffusion/data/dataloader.py
+++ b/polyffusion/data/dataloader.py
@@ -19,7 +19,7 @@ from utils import (
 
 def collate_fn(batch, shift):
     def sample_shift():
-        return np.random.choice(np.arange(-6, 6), 1)[0]
+        return np.random.choice(np.arange(-6, 7), 1)[0]
 
     prmat2c = []
     pnotree = []
@@ -60,12 +60,43 @@ def collate_fn(batch, shift):
     else:
         return prmat2c, pnotree, chord, prmat
 
+def get_custom_train_val_dataloaders(
+    batch_size, data_dir, num_workers=0, pin_memory=False, debug=False, train_ratio=0.9, **kwargs
+):
+    all_data = next(os.walk(data_dir))[2]
+    train_num = int(len(all_data) * train_ratio)
+    train_files = all_data[:train_num]
+    val_files = all_data[train_num:]
+
+    train_dataset = PianoOrchDataset.load_with_song_paths(song_paths=train_files, data_dir=data_dir)
+    val_dataset = PianoOrchDataset.load_with_song_paths(song_paths=val_files, data_dir=data_dir)
+
+    train_dl = DataLoader(
+        train_dataset,
+        batch_size,
+        True,
+        collate_fn=lambda x: collate_fn(x, shift=True),
+        num_workers=num_workers,
+        pin_memory=pin_memory
+    )
+    val_dl = DataLoader(
+        val_dataset,
+        batch_size,
+        True,
+        collate_fn=lambda x: collate_fn(x, shift=False),
+        num_workers=num_workers,
+        pin_memory=pin_memory
+    )
+    print(
+    f"Dataloader ready: batch_size={batch_size}, num_workers={num_workers}, pin_memory={pin_memory}, train_segments={len(train_dataset)}, val_segments={len(val_dataset)} {kwargs}"
+    )
+    return train_dl, val_dl
 
 def get_train_val_dataloaders(
     batch_size, num_workers=0, pin_memory=False, debug=False, **kwargs
 ):
     train_dataset, val_dataset = PianoOrchDataset.load_train_and_valid_sets(
-        debug, **kwargs
+        debug=debug, **kwargs
     )
     train_dl = DataLoader(
         train_dataset,
@@ -84,7 +115,7 @@ def get_train_val_dataloaders(
         pin_memory=pin_memory
     )
     print(
-        f"Dataloader ready: batch_size={batch_size}, num_workers={num_workers}, pin_memory={pin_memory}, {kwargs}"
+    f"Dataloader ready: batch_size={batch_size}, num_workers={num_workers}, pin_memory={pin_memory}, train_segments={len(train_dataset)}, val_segments={len(val_dataset)} {kwargs}"
     )
     return train_dl, val_dl
 

--- a/polyffusion/inference.py
+++ b/polyffusion/inference.py
@@ -7,15 +7,14 @@ from tqdm import tqdm
 from datetime import datetime
 from matplotlib import pyplot as plt
 
-from params import params
-from dataset import DataSampleNpz
+from params.params_ddpm import params
+from data.dataset import DataSampleNpz
 from dirs import *
 from utils import prmat2c_to_midi_file, show_image
 from ddpm import DenoiseDiffusion
 from ddpm.unet import UNet
 from ddpm.utils import gather
-from model import Polyffusion_DDPM
-
+from models.model_ddpm import Polyffusion_DDPM
 
 class Configs():
     # U-Net model for $\textcolor{lightgreen}{\epsilon_\theta}(x_t, t)$
@@ -43,7 +42,7 @@ class Configs():
             device=self.device,
         )
 
-        self.model = Polyffusion_DDPM.load_trained(self.diffusion, model_dir,
+        self.model = Polyffusion_DDPM.load_trained(self.diffusion, os.path.join(model_dir, "chkpts"),
                                                    params).to(self.device)
 
         # self.song_fn, self.pnotree, _ = choose_song_from_val_dl()
@@ -71,7 +70,7 @@ class Configs():
         # $\sigma^2 = \beta$
         self.sigma2 = self.beta
 
-    def _sample_x0(self, xt: torch.Tensor, n_steps: int):
+    def _sample_x0(self, xt: torch.Tensor, n_steps: int, show_img=False):
         """
         #### Sample an image using $\textcolor{lightgreen}{p_\theta}(x_{t-1}|x_t)$
 
@@ -79,7 +78,7 @@ class Configs():
         * `n_steps` is $t$
         """
 
-        # Number of sampels
+        # Number of samples
         n_samples = xt.shape[0]
         # Iterate until $t$ steps
         for t_ in tqdm(range(n_steps), desc="Sampling"):
@@ -89,14 +88,20 @@ class Configs():
                 xt, xt.new_full((n_samples, ), t, dtype=torch.long)
             )
             if t_ % 100 == 0 or (t_ >= 900 and t_ % 25 == 0):
-                show_image(xt, f"exp/x{t}.png")
-                prmat = xt.squeeze().cpu().numpy()
-                prmat2c_to_midi_file(prmat, f"exp/x{t + 1}.mid")
+                if show_img:
+                    show_image(xt, f"exp/x{t}.png")
+                if (n_samples > 1):
+                    prmat = xt.squeeze().cpu().numpy()
+                else:
+                    prmat = xt.cpu().numpy()
+                if show_img:
+                    show_image(xt, f"exp/x{t}.png")
+                    prmat2c_to_midi_file(prmat, f"exp/x{t + 1}.mid")
 
         # Return $x_0$
         return xt
 
-    def sample(self, n_samples: int = 1, init_cond=None, init_step=None):
+    def sample(self, n_samples: int = 1, init_cond=None, init_step=None, show_img=False):
         """
         #### Generate images
         """
@@ -116,7 +121,7 @@ class Configs():
 
         init_step = init_step or self.n_steps
         # $$x_0 \sim \textcolor{lightgreen}{p_\theta}(x_0|x_t)$$
-        x0 = self._sample_x0(xt, init_step)
+        x0 = self._sample_x0(xt, init_step, show_img=show_img)
 
         return x0
 
@@ -141,23 +146,33 @@ class Configs():
         # Sample
         return mean + (var**.5) * eps
 
-    def predict(self, n_samples: int = 16, init_cond=False, init_step=None):
+    def predict(self, n_samples: int = 16, init_cond=False, init_step=None, output_dir="exp", show_img=False):
+        if not os.path.exists(output_dir):
+            os.makedirs(output_dir)
         self.model.eval()
         with torch.no_grad():
             if not init_cond:
-                x0 = self.sample(n_samples)
-                show_image(x0, "exp/x0.png")
-                prmat = x0.squeeze().cpu().numpy()
+                x0 = self.sample(n_samples, show_img=show_img)
+                if show_img:
+                    show_image(x0, os.path.join(output_dir, "x0.png"))
+                if (n_samples > 1):
+                    prmat = x0.squeeze().cpu().numpy()
+                else:
+                    prmat = x0.cpu().numpy()
                 output_stamp = f"ddpm_prmat2c_[uncond]_{datetime.now().strftime('%m-%d_%H%M%S')}"
-                prmat2c_to_midi_file(prmat, f"exp/{output_stamp}.mid")
+                prmat2c_to_midi_file(prmat, os.path.join(output_dir, f"{output_stamp}.mid"))
                 return x0
             else:
                 song_fn, x_init, _ = choose_song_from_val_dl()
-                x0 = self.sample(n_samples, init_cond=x_init, init_step=init_step)
-                show_image(x0, "exp/x0.png")
-                prmat = x0.squeeze().cpu().numpy()
+                x0 = self.sample(n_samples, init_cond=x_init, init_step=init_step, show_img=show_img)
+                if show_img:
+                    show_image(x0, os.path.join(output_dir, "x0.png"))
+                if (n_samples > 1):
+                    prmat = x0.squeeze().cpu().numpy()
+                else:
+                    prmat = x0.cpu().numpy()
                 output_stamp = f"ddpm_prmat2c_init_[{song_fn}]_{datetime.now().strftime('%m-%d_%H%M%S')}"
-                prmat2c_to_midi_file(prmat, f"exp/{output_stamp}.mid")
+                prmat2c_to_midi_file(prmat, os.path.join(output_dir, f"{output_stamp}.mid"))
                 return x0
 
 
@@ -182,6 +197,21 @@ if __name__ == "__main__":
     parser.add_argument(
         "--model_dir", help='directory in which trained model checkpoints are stored'
     )
+    parser.add_argument(
+        "--length", type=int, default=1, help='number of 8 bars to generate'
+    )
+    parser.add_argument(
+        "--output_dir", type=str, default="exp", help='output directory'
+    )
+    parser.add_argument(
+        "--num_generate", type=int, default=1, help='number of inferences'
+    )
+    parser.add_argument(
+        "--show_progress", action='store_true', help='whether to generate progress images and midis'
+    )
     args = parser.parse_args()
+    if not os.path.exists(args.output_dir):
+        os.makedirs(args.output_dir)
     config = Configs(params, args.model_dir)
-    config.predict(n_samples=16, init_cond=False, init_step=100)
+    for i in range(args.num_generate):
+        config.predict(n_samples=args.length, init_cond=False, init_step=100, output_dir=args.output_dir, show_img=args.show_progress)

--- a/polyffusion/inference.py
+++ b/polyffusion/inference.py
@@ -25,7 +25,7 @@ class Configs():
     # Adam optimizer
     optimizer: torch.optim.Adam
 
-    def __init__(self, params, model_dir):
+    def __init__(self, params, model_dir, chkpt_name = "weights_best.pt"):
         self.device = "cuda" if torch.cuda.is_available() else "cpu"
         self.device = torch.device(self.device)
         self.eps_model = UNet(
@@ -42,7 +42,7 @@ class Configs():
             device=self.device,
         )
 
-        self.model = Polyffusion_DDPM.load_trained(self.diffusion, os.path.join(model_dir, "chkpts"),
+        self.model = Polyffusion_DDPM.load_trained(self.diffusion, os.path.join(model_dir, "chkpts", chkpt_name),
                                                    params).to(self.device)
 
         # self.song_fn, self.pnotree, _ = choose_song_from_val_dl()
@@ -209,9 +209,12 @@ if __name__ == "__main__":
     parser.add_argument(
         "--show_progress", action='store_true', help='whether to generate progress images and midis'
     )
+    parser.add_argument(
+        "--chkpt_name", default="weights_best.pt", help="which specific checkpoint to use (default: weights_best.pt)"
+    )
     args = parser.parse_args()
     if not os.path.exists(args.output_dir):
         os.makedirs(args.output_dir)
-    config = Configs(params, args.model_dir)
+    config = Configs(params, args.model_dir, args.chkpt_name)
     for i in range(args.num_generate):
         config.predict(n_samples=args.length, init_cond=False, init_step=100, output_dir=args.output_dir, show_img=args.show_progress)

--- a/polyffusion/learner.py
+++ b/polyffusion/learner.py
@@ -37,6 +37,7 @@ class PolyffusionLearner:
         # restore if directory exists
         if os.path.exists(self.output_dir):
             self.restore_from_checkpoint()
+            print("found previous output directory")
         else:
             os.makedirs(self.output_dir)
             os.makedirs(self.log_dir)

--- a/polyffusion/main.py
+++ b/polyffusion/main.py
@@ -40,24 +40,24 @@ if __name__ == "__main__":
         use_track = [int(x) for x in args.pop909_use_track.split(",")]
 
     if args.model == "ldm_chdvnl":
-        config = LDM_TrainConfig(params_sdf, args.output_dir, use_track=use_track)
+        config = LDM_TrainConfig(params_sdf, args.output_dir, use_track=use_track, data_dir=args.data_dir)
     elif args.model == "ldm_chd8bar":
         config = LDM_TrainConfig(
             params_sdf_chd8bar, args.output_dir, use_track=use_track, data_dir=args.data_dir
         )
     elif args.model == "ldm_pnotree":
         config = LDM_TrainConfig(
-            params_sdf_pnotree, args.output_dir, use_track=use_track
+            params_sdf_pnotree, args.output_dir, use_track=use_track, data_dir=args.data_dir
         )
     elif args.model == "ldm_txt":
-        config = LDM_TrainConfig(params_sdf_txt, args.output_dir, use_track=use_track)
+        config = LDM_TrainConfig(params_sdf_txt, args.output_dir, use_track=use_track, data_dir=args.data_dir)
     elif args.model == "ldm_txtvnl":
         config = LDM_TrainConfig(
-            params_sdf_txtvnl, args.output_dir, use_track=use_track
+            params_sdf_txtvnl, args.output_dir, use_track=use_track, data_dir=args.data_dir
         )
     elif args.model == "ldm_concat":
         config = LDM_TrainConfig(
-            params_sdf_concat, args.output_dir, use_track=use_track
+            params_sdf_concat, args.output_dir, use_track=use_track, data_dir=args.data_dir
         )
     elif args.model == "ldm_musicalion_pnotree":
         config = LDM_TrainConfig(
@@ -68,9 +68,9 @@ if __name__ == "__main__":
     elif args.model == "ddpm":
         config = DDPM_TrainConfig(params_ddpm, args.output_dir, data_dir=args.data_dir)
     elif args.model == "autoencoder":
-        config = Autoencoder_TrainConfig(params_autoencoder, args.output_dir)
+        config = Autoencoder_TrainConfig(params_autoencoder, args.output_dir, data_dir=args.data_dir)
     elif args.model == "chd_8bar":
-        config = Chord8bar_TrainConfig(params_chd_8bar, args.output_dir)
+        config = Chord8bar_TrainConfig(params_chd_8bar, args.output_dir, data_dir=args.data_dir)
     else:
         raise NotImplementedError
     config.train()

--- a/polyffusion/main.py
+++ b/polyffusion/main.py
@@ -25,6 +25,11 @@ if __name__ == "__main__":
         help='directory in which to store model checkpoints and training logs'
     )
     parser.add_argument(
+        "--data_dir",
+        default=None,
+        help='directory of custom training data, in npzs'
+    )
+    parser.add_argument(
         "--pop909_use_track", help='which tracks to use for pop909 training'
     )
     parser.add_argument("--model", help="which model to train (autoencoder, ldm, ddpm)")
@@ -38,7 +43,7 @@ if __name__ == "__main__":
         config = LDM_TrainConfig(params_sdf, args.output_dir, use_track=use_track)
     elif args.model == "ldm_chd8bar":
         config = LDM_TrainConfig(
-            params_sdf_chd8bar, args.output_dir, use_track=use_track
+            params_sdf_chd8bar, args.output_dir, use_track=use_track, data_dir=args.data_dir
         )
     elif args.model == "ldm_pnotree":
         config = LDM_TrainConfig(
@@ -61,7 +66,7 @@ if __name__ == "__main__":
     elif args.model == "ldm_musicalion_txt":
         config = LDM_TrainConfig(params_sdf_txt, args.output_dir, use_musicalion=True)
     elif args.model == "ddpm":
-        config = DDPM_TrainConfig(params_ddpm, args.output_dir)
+        config = DDPM_TrainConfig(params_ddpm, args.output_dir, data_dir=args.data_dir)
     elif args.model == "autoencoder":
         config = Autoencoder_TrainConfig(params_autoencoder, args.output_dir)
     elif args.model == "chd_8bar":

--- a/polyffusion/models/model_ddpm.py
+++ b/polyffusion/models/model_ddpm.py
@@ -18,9 +18,9 @@ class Polyffusion_DDPM(nn.Module):
         self.ddpm = ddpm
 
     @classmethod
-    def load_trained(cls, ddpm, model_dir, params, max_simu_note=20):
+    def load_trained(cls, ddpm, chkpt_fpath, params, max_simu_note=20):
         model = cls(ddpm, params, max_simu_note)
-        trained_leaner = torch.load(f"{model_dir}/weights.pt")
+        trained_leaner = torch.load(chkpt_fpath)
         model.load_state_dict(trained_leaner["model"])
         return model
 

--- a/polyffusion/models/model_ddpm.py
+++ b/polyffusion/models/model_ddpm.py
@@ -30,8 +30,9 @@ class Polyffusion_DDPM(nn.Module):
     def q_sample(self, x0: torch.Tensor, t: torch.Tensor):
         return self.ddpm.q_sample(x0, t)
 
-    def get_loss_dict(self, prmat):
+    def get_loss_dict(self, batch, step):
         """
         z_y is the stuff the diffusion model needs to learn
         """
-        return {"loss": self.ddpm.loss(prmat)}
+        prmat2c, pnotree, chord, prmat = batch
+        return {"loss": self.ddpm.loss(prmat2c)}

--- a/polyffusion/prepare_data.py
+++ b/polyffusion/prepare_data.py
@@ -1,0 +1,104 @@
+import os
+import muspy
+from tqdm import tqdm
+import numpy as np
+from data.midi_to_data import *
+from data.dataset import PianoOrchDataset
+from argparse import ArgumentParser
+
+def force_length(music : muspy.music, bars = 8):
+    for track in music.tracks:
+        timesteps = track.get_end_time()
+        old_bars = (timesteps + 15) // 16
+        div = bars // old_bars
+        for i in range(1, div):
+            tmp = track.deepcopy()
+            tmp.adjust_time(lambda x : x + i * timesteps)
+            track.notes.extend(tmp.notes)
+
+def prepare_npz(midi_dir, chords_dir, output_dir, force=False):
+    for dir in [chords_dir, output_dir]:
+        if not os.path.exists(dir):
+            os.makedirs(dir)
+    ttl = 0
+    success = 0
+    downbeat_errors = 0
+    chords_errors = 0
+    for root, dirs, files in os.walk(midi_dir):
+        for midi in tqdm(files, desc=f"Processing {root}"):
+            ttl += 1
+            fpath = os.path.join(root, midi)
+            chdpath = os.path.join(chords_dir, os.path.splitext(midi)[0] + ".csv")
+            music = muspy.read_midi(fpath)
+            music.adjust_resolution(4)
+            if len(music.time_signatures) == 0:
+                music.time_signatures.append(muspy.TimeSignature(0, 4, 4))
+            if force:
+                force_length(music)
+
+            try:
+                note_mat = get_note_matrix(music)
+                note_mat = dedup_note_matrix(note_mat)
+                extract_chords_from_midi_file(fpath, chdpath)
+                chord = get_chord_matrix(chdpath)
+            except:
+                chords_errors += 1
+                continue
+
+            try:
+                db_pos, db_pos_filter = get_downbeat_pos_and_filter(music, fpath)
+            except:
+                downbeat_errors += 1
+                continue
+            if db_pos is not None and sum(filter(lambda x : x, db_pos_filter)) != 0:
+                start_table = get_start_table(note_mat, db_pos)
+                processed_data = {
+                    "notes": np.array(note_mat),
+                    "start_table": np.array(start_table),
+                    "db_pos": np.array(db_pos),
+                    "db_pos_filter": np.array(db_pos_filter),
+                    "chord": np.array(chord),
+                }
+                np.savez(
+                os.path.join(output_dir, midi),
+                notes=processed_data["notes"],
+                start_table=processed_data["start_table"],
+                db_pos=processed_data["db_pos"],
+                db_pos_filter=processed_data["db_pos_filter"],
+                chord=processed_data["chord"]
+                )
+                success += 1
+            else:
+                downbeat_errors += 1
+
+    print(f"""{ttl} tracks processed, {success} succeeded, {chords_errors} chords errors, {downbeat_errors} downbeat errors""")
+
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser(
+        description='prepare data from midi for a Polyffusion model'
+    )
+    parser.add_argument(
+        "--midi_dir",
+        type=str,
+        help='directory of input midis to preparep'
+    )
+    parser.add_argument(
+        "--chords_dir",
+        type=str,
+        help='directory to store extracted chords'
+    )
+    parser.add_argument(
+        "--npz_dir",
+        type=str,
+        help='directory to store prepared data in npz'
+    )
+    parser.add_argument(
+        "--force_length",
+        action="store_true",
+        help="whether to repeat shorter samples into the desired number of bars"
+    )
+
+    args = parser.parse_args()
+    prepare_npz(args.midi_dir, args.chords_dir, args.npz_dir, args.force_length)

--- a/polyffusion/train/__init__.py
+++ b/polyffusion/train/__init__.py
@@ -4,6 +4,7 @@ import os
 from datetime import datetime
 from torch.utils.data import DataLoader
 from torch.optim import Optimizer
+from shutil import copy2
 
 import sys
 
@@ -25,8 +26,16 @@ class TrainConfig():
         if os.path.exists(f"{output_dir}/params.json"):
             with open(f"{output_dir}/params.json", "r+") as params_file:
                 old_params = AttrDict(json.load(params_file))
+
+                # The "weights" attribute is a tuple in AttrDict, but saved as a list. To compare these two, we make them both tuples:
+                if "weights" in old_params:
+                    old_params["weights"] = tuple(old_params["weights"])
+                
                 if old_params != self.params:
-                    print("New params differ, using new params could break things")
+                    print("New params differ, using new params could break things.")
+                    if input("Do you want to keep the old params file (y/n)? The model will still be trained on new params regardless.") == "y":
+                        time_stamp = datetime.now().strftime('%m-%d_%H%M%S')
+                        copy2(f"{output_dir}/params.json", f"{output_dir}/old_params_{time_stamp}.json")
                     params_file.seek(0)
                     json.dump(self.params, params_file)
                     params_file.truncate()
@@ -42,6 +51,7 @@ class TrainConfig():
             if input("Resume training? (y/n)") != "y":
                 return
         else:
+            output_dir = f"{output_dir}/{datetime.now().strftime('%m-%d_%H%M%S')}"
             print(f"Creating new log folder as {output_dir}")
         learner = PolyffusionLearner(
             output_dir, self.model, self.train_dl, self.val_dl, self.optimizer,

--- a/polyffusion/train/__init__.py
+++ b/polyffusion/train/__init__.py
@@ -23,11 +23,13 @@ class TrainConfig():
         self.param_scheduler = param_scheduler
         self.output_dir = output_dir
         if os.path.exists(f"{output_dir}/params.json"):
-            with open(f"{output_dir}/params.json", "r") as params_file:
-                self.params = AttrDict(json.load(params_file))
-                if params != self.params:
-                    print("New params differ, using former params instead...")
-                    params = self.params
+            with open(f"{output_dir}/params.json", "r+") as params_file:
+                old_params = AttrDict(json.load(params_file))
+                if old_params != self.params:
+                    print("New params differ, using new params could break things")
+                    params_file.seek(0)
+                    json.dump(self.params, params_file)
+                    params_file.truncate()
 
     def train(self):
         total_parameters = sum(
@@ -40,7 +42,6 @@ class TrainConfig():
             if input("Resume training? (y/n)") != "y":
                 return
         else:
-            output_dir = f"{output_dir}/{datetime.now().strftime('%m-%d_%H%M%S')}"
             print(f"Creating new log folder as {output_dir}")
         learner = PolyffusionLearner(
             output_dir, self.model, self.train_dl, self.val_dl, self.optimizer,

--- a/polyffusion/train/train_autoencoder.py
+++ b/polyffusion/train/train_autoencoder.py
@@ -7,7 +7,7 @@ import sys
 from . import TrainConfig
 from learner import PolyffusionLearner
 from stable_diffusion.model.autoencoder import Autoencoder, Encoder, Decoder
-from data.dataloader import get_train_val_dataloaders
+from data.dataloader import get_train_val_dataloaders, get_custom_train_val_dataloaders
 from dirs import *
 from models.model_autoencoder import Polyffusion_Autoencoder
 
@@ -16,7 +16,7 @@ class Autoencoder_TrainConfig(TrainConfig):
     model: Autoencoder
     optimizer: torch.optim.Adam
 
-    def __init__(self, params, output_dir) -> None:
+    def __init__(self, params, output_dir, data_dir=None) -> None:
         super().__init__(params, None, output_dir)
         encoder = Encoder(
             in_channels=params.in_channels,
@@ -44,9 +44,15 @@ class Autoencoder_TrainConfig(TrainConfig):
         self.model = Polyffusion_Autoencoder(autoencoder).to(self.device)
 
         # Create dataloader
-        self.train_dl, self.val_dl = get_train_val_dataloaders(
-            params.batch_size, params.num_workers, params.pin_memory
-        )
+        if data_dir == None:
+            self.train_dl, self.val_dl = get_train_val_dataloaders(
+                params.batch_size, params.num_workers, params.pin_memory
+            )
+        else:
+            self.train_dl, self.val_dl = get_custom_train_val_dataloaders(
+                params.batch_size, data_dir, num_workers=params.num_workers, pin_memory=params.pin_memory
+            )
+        
         # Create optimizer
         self.optimizer = torch.optim.Adam(
             self.model.parameters(), lr=params.learning_rate

--- a/polyffusion/train/train_chd_8bar.py
+++ b/polyffusion/train/train_chd_8bar.py
@@ -4,14 +4,14 @@ import os
 
 # from stable_diffusion.model.autoencoder import Autoencoder, Encoder, Decoder
 from . import *
-from data.dataloader import get_train_val_dataloaders
+from data.dataloader import get_train_val_dataloaders, get_custom_train_val_dataloaders
 from dl_modules import ChordEncoder, ChordDecoder
 from models.model_chd_8bar import Chord_8Bar
 from train.scheduler import TeacherForcingScheduler, ParameterScheduler
 
 
 class Chord8bar_TrainConfig(TrainConfig):
-    def __init__(self, params, output_dir) -> None:
+    def __init__(self, params, output_dir, data_dir=None) -> None:
         # Teacher-forcing rate for Chord VAE training
         tfr_chd = params.tfr_chd
         tfr_chd_scheduler = TeacherForcingScheduler(*tfr_chd)
@@ -36,8 +36,17 @@ class Chord8bar_TrainConfig(TrainConfig):
             self.chord_enc,
             self.chord_dec,
         ).to(self.device)
+        
         # Create dataloader
-        self.train_dl, self.val_dl = get_train_val_dataloaders(params.batch_size)
+        if data_dir == None:
+            self.train_dl, self.val_dl = get_train_val_dataloaders(
+                params.batch_size, params.num_workers, params.pin_memory
+            )
+        else:
+            self.train_dl, self.val_dl = get_custom_train_val_dataloaders(
+                params.batch_size, data_dir, num_workers=params.num_workers, pin_memory=params.pin_memory
+            )
+
         # Create optimizer
         self.optimizer = torch.optim.Adam(
             self.model.parameters(), lr=params.learning_rate

--- a/polyffusion/train/train_ddpm.py
+++ b/polyffusion/train/train_ddpm.py
@@ -5,7 +5,7 @@ from . import *
 from ddpm.unet import UNet
 from ddpm import DenoiseDiffusion
 from models.model_ddpm import Polyffusion_DDPM
-from data.dataloader import get_train_val_dataloaders
+from data.dataloader import get_train_val_dataloaders, get_custom_train_val_dataloaders
 
 
 class DDPM_TrainConfig(TrainConfig):
@@ -17,7 +17,7 @@ class DDPM_TrainConfig(TrainConfig):
     # Adam optimizer
     optimizer: torch.optim.Adam
 
-    def __init__(self, params, output_dir):
+    def __init__(self, params, output_dir, data_dir=None):
         super().__init__(params, None, output_dir)
 
         self.eps_model = UNet(
@@ -36,9 +36,14 @@ class DDPM_TrainConfig(TrainConfig):
 
         self.model = Polyffusion_DDPM(self.diffusion, params).to(self.device)
         # Create dataloader
-        self.train_dl, self.val_dl = get_train_val_dataloaders(
-            params.batch_size, params.num_workers, params.pin_memory
-        )
+        if data_dir == None:
+            self.train_dl, self.val_dl = get_train_val_dataloaders(
+                params.batch_size, params.num_workers, params.pin_memory
+            )
+        else:
+            self.train_dl, self.val_dl = get_custom_train_val_dataloaders(
+                params.batch_size, data_dir, num_workers=params.num_workers, pin_memory=params.pin_memory
+            )
         # Create optimizer
         self.optimizer = torch.optim.Adam(
             self.eps_model.parameters(), lr=params.learning_rate

--- a/polyffusion/train/train_ldm.py
+++ b/polyffusion/train/train_ldm.py
@@ -8,7 +8,7 @@ from . import *
 from stable_diffusion.model.unet import UNetModel
 from stable_diffusion.latent_diffusion import LatentDiffusion
 from models.model_sdf import Polyffusion_SDF
-from data.dataloader import get_train_val_dataloaders
+from data.dataloader import get_train_val_dataloaders, get_custom_train_val_dataloaders
 from data.dataloader_musicalion import get_train_val_dataloaders as get_train_val_dataloaders_musicalion
 from dl_modules import ChordEncoder, ChordDecoder, TextureEncoder
 from dirs import PT_A2S_PATH, PT_CHD_8BAR_PATH, PT_PNOTREE_PATH, PT_POLYDIS_PATH
@@ -23,6 +23,7 @@ class LDM_TrainConfig(TrainConfig):
         use_autoencoder=False,
         use_musicalion=False,
         use_track=[0, 1, 2],
+        data_dir=None,
     ) -> None:
         super().__init__(params, None, output_dir)
         self.autoencoder = None
@@ -111,12 +112,14 @@ class LDM_TrainConfig(TrainConfig):
                 params.batch_size, params.num_workers, params.pin_memory
             )
         else:
-            self.train_dl, self.val_dl = get_train_val_dataloaders(
-                params.batch_size,
-                params.num_workers,
-                params.pin_memory,
-                use_track=use_track
-            )
+            if data_dir == None:
+                self.train_dl, self.val_dl = get_train_val_dataloaders(
+                    params.batch_size, params.num_workers, params.pin_memory
+                )
+            else:
+                self.train_dl, self.val_dl = get_custom_train_val_dataloaders(
+                    params.batch_size, data_dir, num_workers=params.num_workers, pin_memory=params.pin_memory
+                )
 
         # Create optimizer
         self.optimizer = torch.optim.Adam(


### PR DESCRIPTION
This pull request entails:
- Streamlining training on new data directly from midi files using an updated dataloader
- Supporting an arbitrary amount of tracks in the input, as opposed to the fixed (melody, bridge, piano) shape from POP909
- Extending the chord extractor with the option to round the duration of chords to the nearest beat. This significantly reduces error rate in preparing training data, while maintaining a reasonable accuracy
- Fixing `collate_fn` shifting unevenly in dataloader
- Fixing vanilla ddpm model not being able to train with `PolyffusionLearner`
- Fixing ddpm not being able to inference when `length=1`
- Enabling retraining from checkpoint with an increased `max_epochs`
- Implementing several convenient changes for batch inferencing

These changes are mainly just small additions to enhance user experience, and are completely backward-compatible.